### PR TITLE
Positive test case patch: Chai was auto redirecting through every route accessible from POST route for register

### DIFF
--- a/ProjectSourceCode/src/test/server.spec.js
+++ b/ProjectSourceCode/src/test/server.spec.js
@@ -34,6 +34,7 @@ describe('Testing Add User API', () => {
       .request(server)
       .post('/register')
       .send({username: "yusufmorsy", password: "mynameisyusuf"}) // Changed field name
+      .redirects(0) // Prevent following the redirect automatically
       .end((err, res) => {
         expect(res).to.have.status(302); // Expecting a redirect
         expect(res).to.redirectTo(/\/login$/); // Optionally check the redirect URL


### PR DESCRIPTION
Because of how Chai works, it did the redirect to /login GET route correctly from /register POST route (the 302 code), but it then executed /login GET route as well, causing the positive unit case for /register POST route to fail as it was returning the 200 code from the GET route rendering the login page rather than the 302 code from the redirect.

As such, I added the ".redirects(0)" line to ensure it only returns the status code upon redirect (or not) rather than the code for rendering the login page.